### PR TITLE
Fix authorization header token prefix

### DIFF
--- a/src/index.js
+++ b/src/index.js
@@ -30,7 +30,11 @@ export default class Fetch {
 
   buildAuthorizationHeader(key) {
     if (key) {
-      const authKeyword = this.options.defaultAuthorizationKeyword || DEFAULT_AUTHORIZATION_KEYWORD
+      const authKeyword = (
+        this.options.defaultAuthorizationKeyword === undefined
+        ? DEFAULT_AUTHORIZATION_KEYWORD
+        : this.options.defaultAuthorizationKeyword
+      )
       const authHeader = this.options.defaultAuthorizationHeader || DEFAULT_AUTHORIZATION_HEADER
       return {
         [authHeader]: `${authKeyword}${key}`,

--- a/src/index.js
+++ b/src/index.js
@@ -28,7 +28,7 @@ export default class Fetch {
     return new Fetch(defaultURL, defaultHeaders, options)
   }
 
-  buidAuthorizationHeader(key) {
+  buildAuthorizationHeader(key) {
     if (key) {
       const authKeyword = this.options.defaultAuthorizationKeyword || DEFAULT_AUTHORIZATION_KEYWORD
       const authHeader = this.options.defaultAuthorizationHeader || DEFAULT_AUTHORIZATION_HEADER
@@ -41,7 +41,7 @@ export default class Fetch {
 
   request(url, options = {}) {
     const { headers, key, noBaseURL, removeTrailingSlash, params, ...opts } = options
-    const authorization = this.buidAuthorizationHeader(key)
+    const authorization = this.buildAuthorizationHeader(key)
     const finalURL = this.getURL(
       url,
       {


### PR DESCRIPTION
If you pass a blank string to `defaultAuthorizationKeyword` it uses `Token ` anyways.